### PR TITLE
Aquatic types in groundwater schemes: generate input data wrt base sampling frame & samples

### DIFF
--- a/010_aq_piezometer_positioning/010_aq_piezometer_positioning.Rproj
+++ b/010_aq_piezometer_positioning/010_aq_piezometer_positioning.Rproj
@@ -1,0 +1,19 @@
+Version: 1.0
+ProjectId: 7d95a665-394d-416f-b6bd-33d34590175d
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+UseNativePipeOperator: No

--- a/010_aq_piezometer_positioning/code_to_be_moved.R
+++ b/010_aq_piezometer_positioning/code_to_be_moved.R
@@ -1,0 +1,207 @@
+conflictRules("n2khab", exclude = c("read_schemes", "read_scheme_types"))
+library(dplyr)
+library(tidyr)
+library(stringr)
+library(sf)
+library(n2khab)
+library(n2khabmon)
+library(googledrive)
+
+# Setup for googledrive authentication. Set the appropriate env vars in
+# .Renviron and make sure you ran drive_auth() interactively with these settings
+# for the first run (or to renew an expired Oauth token).
+# See ?gargle::gargle_options for more information.
+if (Sys.getenv("GARGLE_OAUTH_EMAIL") != "") {
+  options(gargle_oauth_email = Sys.getenv("GARGLE_OAUTH_EMAIL"))
+}
+if (Sys.getenv("GARGLE_OAUTH_CACHE") != "") {
+  options(gargle_oauth_cache = Sys.getenv("GARGLE_OAUTH_CACHE"))
+}
+
+
+# IDs and geometries of the units of aquatic types are defined by below code
+# - for watersurface types: wsh_pol
+# - for type 7220, partim rivulets: habspring_units_aquatic
+# - for type 3260: segm_3260
+# =============================================================================
+
+# Manually check data source versions (something to be automated by n2khab
+# package in the future, based on preset versions)
+# - watersurfaces_hab: version watersurfaces_hab_v6
+# - habitatstreams: version habitatstreams_2023
+# - habitatsprings: version habitatsprings_2020v2
+file.path(
+  locate_n2khab_data(),
+  c(
+    "20_processed/watersurfaces_hab",
+    "10_raw/habitatsprings",
+    "10_raw/habitatstreams"
+  )
+) %>%
+  list.files(full.names = TRUE) %>%
+  xxh64sum() %>%
+  identical(c(
+    habitatsprings.geojson = "7268c26f52fcefe4",
+    habitatstreams.dbf = "dee7a620e3bcae0a",
+    habitatstreams.lyr = "a120f92d80c92a3a",
+    habitatstreams.prj = "7e64ff1751a50937",
+    habitatstreams.shp = "5a7d7cddcc52c5df",
+    habitatstreams.shx = "b2087e6affe744f4",
+    habitatstreams.sld = "2f192b84b4df99e9",
+    watersurfaces_hab.gpkg = "e2920c4932008387"
+  )) %>%
+  stopifnot()
+
+# Generating wsh_pol (unit ID defined by polygon_id)
+n2khab_targetpops <-
+  read_scheme_types() %>%
+  select(scheme, type)
+n2khab_types <-
+  n2khab_targetpops %>%
+  distinct(type) %>%
+  arrange(type)
+wsh <- read_watersurfaces_hab(interpreted = TRUE)
+wsh_occ <-
+  wsh$watersurfaces_types %>%
+  # in general we restrict types using an expanded type list tailored to the
+  # type levels present in data sources, but for the aquatic types expansion and
+  # subsequent collapse of types are redundant steps
+  semi_join(n2khab_types, join_by(type))
+wsh_pol <-
+  wsh$watersurfaces_polygons %>%
+  semi_join(wsh_occ, join_by(polygon_id)) %>%
+  select(polygon_id)
+wsh_pol
+
+# Temporary approach to generate segm_3260 (i.e. it will miss a part and some
+# may be false positives)
+# (unit ID defined by unit_id)
+habstream <- read_habitatstreams()
+segm_3260 <-
+  read_watercourse_100mseg(element = "lines")[habstream, ] %>%
+  unite(unit_id, vhag_code, rank)
+segm_3260
+
+# Generating habspring_units_aquatic (unit ID defined by unit_id)
+flanders_buffer <-
+  read_admin_areas(dsn = "flanders") %>%
+  st_buffer(40)
+habspring_units_aquatic <-
+  # following function will be adapted to support the latest version of the data
+  # source (just released); for now use version habitatsprings_2020v2
+  read_habitatsprings(units_7220 = TRUE) %>%
+  .[flanders_buffer, ] %>%
+  filter(system_type != "mire")
+habspring_units_aquatic
+
+
+
+# Define the unit IDs per sample support for aquatic strata in groundwater
+# schemes of the considered MNE modules
+# =============================================================================
+
+# Download and load a few R objects from the POC (these would currently take too
+# much code to regenerate here)
+path <- file.path(tempdir(), "objects_for_aq_piezometers_panfl_pan5.RData")
+drive_download(as_id("1Z93w-C3XRQ8756W3835JPfxggGEstjKR"), path = path)
+env_extradata <- new.env()
+load(path, envir = env_extradata)
+ls(envir = env_extradata)
+
+# Below object can be used to filter the foregoing geospatial objects, taking
+# into account that:
+# - rows with sample_support_code 'watersurface' relate to the IDs in wsh_pol
+# - rows with sample_support_code 'watercourse_segment' relate to the IDs in
+# segm_3260
+# - rows with sample_support_code 'spring' relate to the IDs in
+# habspring_units_aquatic
+stratum_units_grts_aquatic_gw_spsamples_spares <-
+  # units per stratum:
+  get("stratum_units_non_cell_n2khab", envir = env_extradata) %>%
+  # joining GRTS address per unit. A few non-unique GRTS addresses exist, hence
+  # 'many-to-one'. See further.
+  inner_join(
+    get("units_non_cell_n2khab_grts", envir = env_extradata),
+    join_by(sample_support_code, unit_id),
+    relationship = "many-to-one",
+    unmatched = "error"
+  ) %>%
+  filter(
+    # other 'non-cell' types exist so these must be dropped:
+    sample_support_code %in% c(
+      "watersurface",
+      "watercourse_segment",
+      "spring"
+    ),
+    # terrestrial spring units must also be excluded:
+    unit_id %in% habspring_units_aquatic$unit_id |
+      sample_support_code != "spring"
+  ) %>%
+  rename(grts_address_final = grts_address) %>%
+  # join with samples ('sample_status' defines whether location is 'in the
+  # sample' or is a 'spare unit' (spare units = a bunch of 'next' GRTS addresses
+  # in the available GRTS series for a stratum))
+  inner_join(
+    get(
+      "scheme_moco_ps_stratum_sppost_spsamples_spares_sf",
+      envir = env_extradata
+    ) %>%
+      st_drop_geometry() %>%
+      # only use the samples of groundwater schemes
+      filter(str_detect(scheme, "^GW")) %>%
+      rename(grts_address_drawn = grts_address) %>%
+      # collapse module combos and schemes; hereby select the 'prior'
+      # sample_status ("in_sample") across module combos and schemes:
+      summarize(
+        sample_status = sample_status %>% droplevels() %>% levels() %>%  first(),
+        .by = c(
+          stratum,
+          grts_address_drawn,
+          grts_address_final
+        )
+      ) %>%
+      mutate(sample_status = factor(sample_status)),
+    join_by(stratum, grts_address_final),
+    # A few non-unique GRTS addresses exist, hence 'many-to-one'. We will apply
+    # a quick-fix below to meet the requirement of 'one unit sampled per GRTS
+    # address', but at least the selection will need further alignment with the
+    # (likewise) MHQ solution (to be continued).
+    relationship = "many-to-one",
+    unmatched = "drop"
+  ) %>%
+  arrange(sample_support_code, stratum, grts_address_drawn, unit_id) %>%
+  # for now, de-duplicate units with the same GRTS address by selecting the 1st
+  slice(1, .by = c(stratum, sample_support_code, grts_address_final)) %>%
+  select(-grts_address_drawn)
+stratum_units_grts_aquatic_gw_spsamples_spares
+
+# Checking that all retained unit IDs from the samples are represented in the
+# geospatial objects
+stratum_units_grts_aquatic_gw_spsamples_spares %>%
+  filter(sample_support_code == "watersurface") %>%
+  {all(.$unit_id %in% wsh_pol$polygon_id)} %>%
+  stopifnot()
+
+stratum_units_grts_aquatic_gw_spsamples_spares %>%
+  filter(sample_support_code == "watercourse_segment") %>%
+  {all(.$unit_id %in% segm_3260$unit_id)} %>%
+  stopifnot()
+
+stratum_units_grts_aquatic_gw_spsamples_spares %>%
+  filter(sample_support_code == "spring") %>%
+  {all(.$unit_id %in% habspring_units_aquatic$unit_id)} %>%
+  stopifnot()
+
+
+
+
+# Adding some possible inspiration (in Dutch) from a former selection of
+# Watina data for analysis
+# =============================================================================
+
+# Voor aquatische objecten (excl. 7220) wordt een buffer van 30 meter gebruikt:
+# grondwater in de nabije omgeving wordt er beschouwd in relatie tot het
+# oppervlaktewater. Voor waterplassen wordt daarbij het watervlak zelf niet in
+# rekening gebracht: hier worden dus ringen rond de plas gecreëerd. Voor type
+# 7220 wordt een straal van 40 meter gebruikt omdat de locaties slechts als een
+# punt zijn gedigitaliseerd.

--- a/010_aq_piezometer_positioning/code_to_be_moved.R
+++ b/010_aq_piezometer_positioning/code_to_be_moved.R
@@ -42,6 +42,7 @@ file.path(
 ) %>%
   list.files(full.names = TRUE) %>%
   xxh64sum() %>%
+  .[sort(names(.))] %>%
   identical(c(
     flanders.dbf = "d21a599325723682",
     flanders.prj = "2f10404ffd869596",

--- a/010_aq_piezometer_positioning/code_to_be_moved.R
+++ b/010_aq_piezometer_positioning/code_to_be_moved.R
@@ -30,17 +30,23 @@ if (Sys.getenv("GARGLE_OAUTH_CACHE") != "") {
 # - watersurfaces_hab: version watersurfaces_hab_v6
 # - habitatstreams: version habitatstreams_2023
 # - habitatsprings: version habitatsprings_2020v2
+# - flanders: version "flanders_2018-05-16"
 file.path(
   locate_n2khab_data(),
   c(
     "20_processed/watersurfaces_hab",
     "10_raw/habitatsprings",
-    "10_raw/habitatstreams"
+    "10_raw/habitatstreams",
+    "10_raw/flanders"
   )
 ) %>%
   list.files(full.names = TRUE) %>%
   xxh64sum() %>%
   identical(c(
+    flanders.dbf = "d21a599325723682",
+    flanders.prj = "2f10404ffd869596",
+    flanders.shp = "72fff53084b356be",
+    flanders.shx = "1880e141bbcdc6ca",
     habitatsprings.geojson = "7268c26f52fcefe4",
     habitatstreams.dbf = "dee7a620e3bcae0a",
     habitatstreams.lyr = "a120f92d80c92a3a",


### PR DESCRIPTION
This PR adds an R-script that generates sampling frame & sample data to support the challenge to delineate areas or determine directions where piezometer and observation well should be installed in the vicinity of an aquatic population unit in groundwater schemes.

Two types of objects are generated:

- **geospatial objects** (sf) that define the geometry of each population unit in the base sampling frame with regard to aquatic types (the base sampling frame can be seen as the integration of scheme-specific sampling frames, which can be more restricted). One object is made for each 'sample support'. The sample support determines the spatial characteristics (nature) of a population unit; here it's either watersurface, spring or watercourse segment.
  - In the case of springs (type 7220 partim 'rivulets'), we don't have the actual spatial dimensions of the population unit, which in this case is defined as the local area where the habitat type 7220 occurs in a rivulet (small spring stream). Each unit is just represented by a point. There's an indication of unit size in an attribute of the object.
  - Note that these objects describe all population units available for sampling, which is far more than the actual samples.
- an **object with the integrated samples** (s.l.: including a bunch of spare units, i.e. not currently in the sample) of the  involved groundwater schemes and limited to the aquatic types (integrated: the distinction between schemes is removed). It includes the `unit_id` and `sample_support_code` attributes needed to subsequently filter the foregoing spatial objects.
  - Note that this object also distinguishes between different strata (types or subdivisions thereoff, such as `3130_0_1`, which is the stratum of type `3130` where the watersurface is between 0 and 1 ha). It may rightfully duplicate locations in the case of aquatic types, where more than one type may be present in a surface water body.

The latter object, as currently generated in the demo code below, is contingent on just the following modules being activated in the POC, at tag `poc_0.4.1` (code from POC below):

```r
> modules %>% select(module, code_short, name_en)
# A tibble: 2 × 3
  module                        code_short name_en                                                                                                          
  <fct>                         <fct>      <fct>                                                                                                            
1 pan_effectmon_flanders        panfl      Programmatic Approach Nitrogen (PAN) effect monitoring in Flanders                                               
2 pan_effectmon_sac5_custommeas pan5       Programmatic Approach Nitrogen (PAN) effect monitoring in five Special Areas of Conservation with custom measures
```

This POC relation and above code is just for your information; the script should run stand-alone provided that the needed data sources are present in the `n2khab_data` directory.

<details><summary><strong>Demonstration of current output</strong></summary>

``` r
conflictRules("n2khab", exclude = c("read_schemes", "read_scheme_types"))
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
library(tidyr)
library(stringr)
library(sf)
#> Linking to GEOS 3.12.2, GDAL 3.9.3, PROJ 9.4.1; sf_use_s2() is TRUE
library(n2khab)
#> Attaching n2khab 0.12.0.9000.
#> Will use sf 1.0-19.
#> Will use terra 1.8-29.
library(n2khabmon)
#> Attaching n2khabmon 0.3.1.
library(googledrive)

# Setup for googledrive authentication. Set the appropriate env vars in
# .Renviron and make sure you ran drive_auth() interactively with these settings
# for the first run (or to renew an expired Oauth token).
# See ?gargle::gargle_options for more information.
if (Sys.getenv("GARGLE_OAUTH_EMAIL") != "") {
  options(gargle_oauth_email = Sys.getenv("GARGLE_OAUTH_EMAIL"))
}
if (Sys.getenv("GARGLE_OAUTH_CACHE") != "") {
  options(gargle_oauth_cache = Sys.getenv("GARGLE_OAUTH_CACHE"))
}


# IDs and geometries of the units of aquatic types are defined by below code
# - for watersurface types: wsh_pol
# - for type 7220, partim rivulets: habspring_units_aquatic
# - for type 3260: segm_3260
# =============================================================================

# Manually check data source versions (something to be automated by n2khab
# package in the future, based on preset versions)
# - watersurfaces_hab: version watersurfaces_hab_v6
# - habitatstreams: version habitatstreams_2023
# - habitatsprings: version habitatsprings_2020v2
file.path(
  locate_n2khab_data(),
  c(
    "20_processed/watersurfaces_hab",
    "10_raw/habitatsprings",
    "10_raw/habitatstreams"
  )
) %>%
  list.files(full.names = TRUE) %>%
  xxh64sum() %>%
  identical(c(
    habitatsprings.geojson = "7268c26f52fcefe4",
    habitatstreams.dbf = "dee7a620e3bcae0a",
    habitatstreams.lyr = "a120f92d80c92a3a",
    habitatstreams.prj = "7e64ff1751a50937",
    habitatstreams.shp = "5a7d7cddcc52c5df",
    habitatstreams.shx = "b2087e6affe744f4",
    habitatstreams.sld = "2f192b84b4df99e9",
    watersurfaces_hab.gpkg = "e2920c4932008387"
  )) %>%
  stopifnot()

# Generating wsh_pol (unit ID defined by polygon_id)
n2khab_targetpops <-
  read_scheme_types() %>%
  select(scheme, type)
n2khab_types <-
  n2khab_targetpops %>%
  distinct(type) %>%
  arrange(type)
wsh <- read_watersurfaces_hab(interpreted = TRUE)
wsh_occ <-
  wsh$watersurfaces_types %>%
  # in general we restrict types using an expanded type list tailored to the
  # type levels present in data sources, but for the aquatic types expansion and
  # subsequent collapse of types are redundant steps
  semi_join(n2khab_types, join_by(type))
wsh_pol <-
  wsh$watersurfaces_polygons %>%
  semi_join(wsh_occ, join_by(polygon_id)) %>%
  select(polygon_id)
wsh_pol
#> Simple feature collection with 3406 features and 1 field
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: 22546.57 ymin: 161611 xmax: 253896.9 ymax: 242960.1
#> Projected CRS: BD72 / Belgian Lambert 72
#> # A tibble: 3,406 × 2
#>    polygon_id                                                               geom
#>    <fct>                                                      <MULTIPOLYGON [m]>
#>  1 ANTANT0082 (((152683 205600.1, 152669.9 205600.4, 152664.2 205604.1, 152656.…
#>  2 ANTANT0234 (((146548.3 225155.3, 146549.5 225155.3, 146550.4 225155.6, 14655…
#>  3 ANTANT0238 (((149155.1 220157.3, 149169.5 220153, 149184.9 220149.1, 149195.…
#>  4 ANTANT0251 (((149696.2 220296, 149695 220296, 149694 220296.3, 149692.7 2203…
#>  5 ANTANT0253 (((149860.6 220244.5, 149861.3 220244.4, 149862.1 220244.6, 14986…
#>  6 ANTANT0297 (((151482.7 219330.4, 151477.5 219336.5, 151470.8 219344.2, 15146…
#>  7 ANTANT0315 (((151255.3 218827.4, 151255.9 218826.8, 151256.4 218826.9, 15125…
#>  8 ANTANT0319 (((151300.6 218630.6, 151301.3 218630.5, 151302.4 218630.6, 15130…
#>  9 ANTANT0381 (((148445.5 209232.7, 148469.7 209267.2, 148471.3 209275.6, 14847…
#> 10 ANTANT0383 (((148349.7 208706.1, 148349.9 208713.8, 148350.2 208716.7, 14835…
#> # ℹ 3,396 more rows

# Temporary approach to generate segm_3260 (i.e. it will miss a part and some
# may be false positives)
# (unit ID defined by unit_id)
habstream <- read_habitatstreams()
segm_3260 <-
  read_watercourse_100mseg(element = "lines")[habstream, ] %>%
  unite(unit_id, vhag_code, rank)
segm_3260
#> Simple feature collection with 1775 features and 1 field
#> Geometry type: LINESTRING
#> Dimension:     XY
#> Bounding box:  xmin: 33105.97 ymin: 157472.1 xmax: 257053.8 ymax: 243446
#> Projected CRS: BD72 / Belgian Lambert 72
#> # A tibble: 1,775 × 2
#>    unit_id                                                                  geom
#>    <chr>                                                        <LINESTRING [m]>
#>  1 460_580  (209143.7 215628.3, 209155.4 215615.4, 209179.1 215595.5, 209186.5 …
#>  2 460_581  (209223.9 215570.2, 209235.7 215564.2, 209256 215551.3, 209270.5 21…
#>  3 460_582  (209313.1 215525.3, 209328.7 215519.1, 209353.6 215510.3, 209385.7 …
#>  4 460_583  (209407 215491, 209411.7 215489.1, 209425.2 215482.9, 209432.6 2154…
#>  5 460_587  (209567.1 215141.1, 209567.2 215136.2, 209568.4 215117.8, 209568.2 …
#>  6 460_588  (209569.8 215041.1, 209570.2 215025.9, 209571 215000.8, 209572.2 21…
#>  7 460_589  (209573.7 214941.2, 209574.6 214931.5, 209575 214920, 209575.4 2149…
#>  8 460_590  (209577.6 214841.4, 209578.2 214824.1, 209578 214810.9, 209578.8 21…
#>  9 460_591  (209590.2 214743, 209594.4 214733.7, 209602.6 214715.4, 209611.4 21…
#> 10 113_5508 (148687.3 225722.9, 148718.8 225724, 148724.3 225724.2, 148736.4 22…
#> # ℹ 1,765 more rows

# Generating habspring_units_aquatic (unit ID defined by unit_id)
flanders_buffer <-
  read_admin_areas(dsn = "flanders") %>%
  st_buffer(40)
habspring_units_aquatic <-
  # following function will be adapted to support the latest version of the data
  # source (just released); for now use version habitatsprings_2020v2
  read_habitatsprings(units_7220 = TRUE) %>%
  .[flanders_buffer, ] %>%
  filter(system_type != "mire")
habspring_units_aquatic
#> Simple feature collection with 41 features and 11 fields
#> Geometry type: POINT
#> Dimension:     XY
#> Bounding box:  xmin: 91418.16 ymin: 155505.7 xmax: 258319.5 ymax: 175602.7
#> Projected CRS: BD72 / Belgian Lambert 72
#> # A tibble: 41 × 12
#>    unit_id nr_of_points name   system_type code_orig type  certain area_m2  year
#>  *   <int>        <int> <chr>  <fct>       <chr>     <fct> <lgl>     <dbl> <dbl>
#>  1       1            2 Steen… rivulet     7220      7220  TRUE         70  2014
#>  2       2            2 Remer… rivulet     7220      7220  TRUE        700  2014
#>  3       3            2 Krind… rivulet     7220      7220  TRUE        900  2014
#>  4       4            1 Bois … rivulet     7220      7220  TRUE         50  2014
#>  5       6            1 Fonte… unknown     7220      7220  TRUE         20  2014
#>  6       8            2 Feelb… unknown     7220,gh   7220  TRUE         NA    NA
#>  7       9            1 Melde… rivulet     7220      7220  TRUE         10  2014
#>  8      11            1 Haren  rivulet     7220      7220  TRUE         10  2014
#>  9      12            1 Borgl… rivulet     7220      7220  TRUE         50  2014
#> 10      13            1 Groot… rivulet     7220      7220  TRUE         30  2014
#> # ℹ 31 more rows
#> # ℹ 3 more variables: in_sac <lgl>, source <chr>, geometry <POINT [m]>



# Define the unit IDs per sample support for aquatic strata in groundwater
# schemes of the considered MNE modules
# =============================================================================

# Download and load a few R objects from the POC (these would currently take too
# much code to regenerate here)
path <- file.path(tempdir(), "objects_for_aq_piezometers_panfl_pan5.RData")
drive_download(as_id("1Z93w-C3XRQ8756W3835JPfxggGEstjKR"), path = path)
#> Auto-refreshing stale OAuth token.
#> File downloaded:
#> • 'objects_for_aq_piezometers_panfl_pan5.RData'
#>   <id: 1Z93w-C3XRQ8756W3835JPfxggGEstjKR>
#> Saved locally as:
#> • '/tmp/RtmpwY031w/objects_for_aq_piezometers_panfl_pan5.RData'
env_extradata <- new.env()
load(path, envir = env_extradata)
ls(envir = env_extradata)
#> [1] "scheme_moco_ps_stratum_sppost_spsamples_spares_sf"
#> [2] "stratum_units_non_cell_n2khab"                    
#> [3] "units_non_cell_n2khab_grts"

# Below object can be used to filter the foregoing geospatial objects, taking
# into account that:
# - rows with sample_support_code 'watersurface' relate to the IDs in wsh_pol
# - rows with sample_support_code 'watercourse_segment' relate to the IDs in
# segm_3260
# - rows with sample_support_code 'spring' relate to the IDs in
# habspring_units_aquatic
stratum_units_grts_aquatic_gw_spsamples_spares <-
  # units per stratum:
  get("stratum_units_non_cell_n2khab", envir = env_extradata) %>%
  # joining GRTS address per unit. A few non-unique GRTS addresses exist, hence
  # 'many-to-one'. See further.
  inner_join(
    get("units_non_cell_n2khab_grts", envir = env_extradata),
    join_by(sample_support_code, unit_id),
    relationship = "many-to-one",
    unmatched = "error"
  ) %>%
  filter(
    # other 'non-cell' types exist so these must be dropped:
    sample_support_code %in% c(
      "watersurface",
      "watercourse_segment",
      "spring"
    ),
    # terrestrial spring units must also be excluded:
    unit_id %in% habspring_units_aquatic$unit_id |
      sample_support_code != "spring"
  ) %>%
  rename(grts_address_final = grts_address) %>%
  # join with samples ('sample_status' defines whether location is 'in the
  # sample' or is a 'spare unit' (spare units = a bunch of 'next' GRTS addresses
  # in the available GRTS series for a stratum))
  inner_join(
    get(
      "scheme_moco_ps_stratum_sppost_spsamples_spares_sf",
      envir = env_extradata
    ) %>%
      st_drop_geometry() %>%
      # only use the samples of groundwater schemes
      filter(str_detect(scheme, "^GW")) %>%
      rename(grts_address_drawn = grts_address) %>%
      # collapse module combos and schemes; hereby select the 'prior'
      # sample_status ("in_sample") across module combos and schemes:
      summarize(
        sample_status = sample_status %>% droplevels() %>% levels() %>%  first(),
        .by = c(
          stratum,
          grts_address_drawn,
          grts_address_final
        )
      ) %>%
      mutate(sample_status = factor(sample_status)),
    join_by(stratum, grts_address_final),
    # A few non-unique GRTS addresses exist, hence 'many-to-one'. We will apply
    # a quick-fix below to meet the requirement of 'one unit sampled per GRTS
    # address', but at least the selection will need further alignment with the
    # (likewise) MHQ solution (to be continued).
    relationship = "many-to-one",
    unmatched = "drop"
  ) %>%
  arrange(sample_support_code, stratum, grts_address_drawn, unit_id) %>%
  # for now, de-duplicate units with the same GRTS address by selecting the 1st
  slice(1, .by = c(stratum, sample_support_code, grts_address_final)) %>%
  select(-grts_address_drawn)
stratum_units_grts_aquatic_gw_spsamples_spares
#> # A tibble: 403 × 5
#>    stratum sample_support_code unit_id grts_address_final sample_status
#>    <fct>   <fct>               <chr>                <int> <fct>        
#>  1 7220    spring              34                 1080377 in_sample    
#>  2 7220    spring              30                 5500121 in_sample    
#>  3 7220    spring              26                 6560882 in_sample    
#>  4 7220    spring              49                 9549529 in_sample    
#>  5 7220    spring              2                 10645378 in_sample    
#>  6 7220    spring              20                11971110 in_sample    
#>  7 7220    spring              53                12686521 in_sample    
#>  8 7220    spring              44                15639737 in_sample    
#>  9 7220    spring              21                16848710 in_sample    
#> 10 7220    spring              6                 19382809 in_sample    
#> # ℹ 393 more rows

# Checking that all retained unit IDs from the samples are represented in the
# geospatial objects
stratum_units_grts_aquatic_gw_spsamples_spares %>%
  filter(sample_support_code == "watersurface") %>%
  {all(.$unit_id %in% wsh_pol$polygon_id)} %>%
  stopifnot()

stratum_units_grts_aquatic_gw_spsamples_spares %>%
  filter(sample_support_code == "watercourse_segment") %>%
  {all(.$unit_id %in% segm_3260$unit_id)} %>%
  stopifnot()

stratum_units_grts_aquatic_gw_spsamples_spares %>%
  filter(sample_support_code == "spring") %>%
  {all(.$unit_id %in% habspring_units_aquatic$unit_id)} %>%
  stopifnot()




# Adding some possible inspiration (in Dutch) from a former selection of
# Watina data for analysis
# =============================================================================

# Voor aquatische objecten (excl. 7220) wordt een buffer van 30 meter gebruikt:
# grondwater in de nabije omgeving wordt er beschouwd in relatie tot het
# oppervlaktewater. Voor waterplassen wordt daarbij het watervlak zelf niet in
# rekening gebracht: hier worden dus ringen rond de plas gecreëerd. Voor type
# 7220 wordt een straal van 40 meter gebruikt omdat de locaties slechts als een
# punt zijn gedigitaliseerd.
```

<sup>Created on 2025-03-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.4.3 (2025-02-28)
#>  os       Linux Mint 22.1
#>  system   x86_64, linux-gnu
#>  ui       X11
#>  language nl_BE:nl
#>  collate  nl_BE.UTF-8
#>  ctype    nl_BE.UTF-8
#>  tz       Europe/Brussels
#>  date     2025-03-21
#>  pandoc   3.2 @ /usr/lib/rstudio/resources/app/bin/quarto/bin/tools/x86_64/ (via rmarkdown)
#>  quarto   1.5.57 @ /usr/lib/rstudio/resources/app/bin/quarto/bin/quarto
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version     date (UTC) lib source
#>  askpass       1.2.1       2024-10-04 [1] RSPM (R 4.4.0)
#>  assertthat    0.2.1       2019-03-21 [1] RSPM (R 4.4.0)
#>  class         7.3-23      2025-01-01 [1] RSPM (R 4.4.0)
#>  classInt      0.4-11      2025-01-08 [1] RSPM (R 4.4.0)
#>  cli           3.6.4       2025-02-13 [1] RSPM (R 4.4.2)
#>  curl          6.2.1       2025-02-19 [1] RSPM (R 4.4.2)
#>  DBI           1.2.3       2024-06-02 [1] RSPM (R 4.4.0)
#>  digest        0.6.37      2024-08-19 [1] RSPM (R 4.4.2)
#>  dplyr       * 1.1.4       2023-11-17 [1] RSPM (R 4.4.0)
#>  e1071         1.7-16      2024-09-16 [1] RSPM (R 4.4.0)
#>  evaluate      1.0.3       2025-01-10 [1] RSPM (R 4.4.0)
#>  fastmap       1.2.0       2024-05-15 [1] RSPM (R 4.4.2)
#>  forcats       1.0.0       2023-01-29 [1] RSPM (R 4.4.0)
#>  fs            1.6.5       2024-10-30 [1] RSPM (R 4.4.2)
#>  gargle        1.5.2       2023-07-20 [1] RSPM (R 4.4.0)
#>  generics      0.1.3       2022-07-05 [1] RSPM (R 4.4.0)
#>  git2r         0.35.0      2024-10-20 [1] RSPM (R 4.4.0)
#>  git2rdata     0.5.0       2025-01-24 [1] RSPM (R 4.4.0)
#>  glue          1.8.0       2024-09-30 [1] RSPM (R 4.4.2)
#>  googledrive * 2.1.1       2023-06-11 [1] RSPM (R 4.4.0)
#>  htmltools     0.5.8.1     2024-04-04 [1] RSPM (R 4.4.0)
#>  httr          1.4.7       2023-08-15 [1] RSPM (R 4.4.0)
#>  jsonlite      1.9.1       2025-03-03 [1] RSPM (R 4.4.0)
#>  KernSmooth    2.23-26     2025-01-01 [1] RSPM (R 4.4.0)
#>  knitr         1.50        2025-03-16 [1] RSPM (R 4.4.0)
#>  lifecycle     1.0.4       2023-11-07 [1] RSPM (R 4.4.0)
#>  magrittr      2.0.3       2022-03-30 [1] RSPM (R 4.4.2)
#>  n2khab      * 0.12.0.9000 2025-03-10 [1] Github (inbo/n2khab@55af149)
#>  n2khabmon   * 0.3.1       2025-03-10 [1] https://inbo.r-universe.dev (R 4.4.3)
#>  openssl       2.3.2       2025-02-03 [1] RSPM (R 4.4.0)
#>  pillar        1.10.1      2025-01-07 [1] RSPM (R 4.4.0)
#>  pkgconfig     2.0.3       2019-09-22 [1] RSPM (R 4.4.0)
#>  plyr          1.8.9       2023-10-02 [1] RSPM (R 4.4.0)
#>  proxy         0.4-27      2022-06-09 [1] RSPM (R 4.4.2)
#>  purrr         1.0.4       2025-02-05 [1] RSPM (R 4.4.0)
#>  R6            2.6.1       2025-02-15 [1] RSPM (R 4.4.0)
#>  Rcpp          1.0.14      2025-01-12 [1] RSPM (R 4.4.2)
#>  remotes       2.5.0       2024-03-17 [1] RSPM (R 4.4.0)
#>  reprex        2.1.1       2024-07-06 [3] RSPM (R 4.4.0)
#>  rlang         1.1.5       2025-01-17 [1] RSPM (R 4.4.2)
#>  rmarkdown     2.29        2024-11-04 [1] RSPM (R 4.4.0)
#>  rprojroot     2.0.4       2023-11-05 [1] RSPM (R 4.4.0)
#>  rstudioapi    0.17.1      2024-10-22 [1] RSPM (R 4.4.0)
#>  sessioninfo   1.2.3       2025-02-05 [1] RSPM (R 4.4.0)
#>  sf          * 1.0-19      2024-11-05 [1] RSPM (R 4.4.3)
#>  stringi       1.8.4       2024-05-06 [1] RSPM (R 4.4.2)
#>  stringr     * 1.5.1       2023-11-14 [1] RSPM (R 4.4.0)
#>  tibble        3.2.1       2023-03-20 [1] RSPM (R 4.4.2)
#>  tidyr       * 1.3.1       2024-01-24 [1] RSPM (R 4.4.0)
#>  tidyselect    1.2.1       2024-03-11 [1] RSPM (R 4.4.0)
#>  units         0.8-7       2025-03-11 [1] RSPM (R 4.4.0)
#>  utf8          1.2.4       2023-10-22 [1] RSPM (R 4.4.2)
#>  vctrs         0.6.5       2023-12-01 [1] RSPM (R 4.4.0)
#>  withr         3.0.2       2024-10-28 [1] RSPM (R 4.4.0)
#>  xfun          0.51        2025-02-19 [1] RSPM (R 4.4.2)
#>  yaml          2.3.10      2024-07-26 [1] RSPM (R 4.4.2)
#> 
#>  [1] /home/floris/lib/R/library
#>  [2] /usr/local/lib/R/site-library
#>  [3] /usr/lib/R/site-library
#>  [4] /usr/lib/R/library
#>  * ── Packages attached to the search path.
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>

</details>

@falkmielke my current idea is that you can move this code to your technical report in the right place; once the script has become redundant, you can remove it.

I also made a directory to store the script and chose a name for it, but you're welcome to organize better, as the repo grows or right away.

I propose to merge this PR if the code works for you and the contents are clear (otherwise we can still discuss here and I can update code comments as needed). After that, you can start your work in your own branch that starts from `main`, and move content as needed.