### PR TITLE
Snippets: replace `case_match` with `recode_values`

### DIFF
--- a/020_fieldwork_organization/R/misc.R
+++ b/020_fieldwork_organization/R/misc.R
@@ -16,14 +16,14 @@
 collapse_strata <- function(df) {
   df %>%
     mutate(
-      stratum = case_match(
+      stratum = recode_values(
         stratum,
         "5130_hei" ~ "5130",
         "5130_kalk" ~ "5130",
         "rbbkam+" ~ "rbbkam",
         "rbbzil+" ~ "rbbzil",
         "9120_qb" ~ "9120",
-        .default = stratum
+        default = stratum
       )
     ) %>%
     left_join(


### PR DESCRIPTION
(triv.)

replacing a deprecated dplyr function in `020_fieldwork_organization/R/misc.R`

following

- <https://tidyverse.org/blog/2026/02/dplyr-1-2-0/>
- <https://dplyr.tidyverse.org/reference/recode-and-replace-values.html>