### PR TITLE
snippets_minor: ambiguity of function name `extract` causes issues

### DIFF
--- a/020_fieldwork_organization/code_snippets.R
+++ b/020_fieldwork_organization/code_snippets.R
@@ -398,8 +398,8 @@ missing_polygons <-
 
 # adding all GRTS addresses that belong to these polygons, by cell-center
 missing_pol_grts <-
-  extract(grts_mh, missing_polygons, small = FALSE) %>%
-  as_tibble() %>%
+  terra::extract(grts_mh, missing_polygons, small = FALSE) %>%
+  dplyr::as_tibble() %>%
   inner_join_12m_e(
     tibble(
       ID = seq_len(nrow(missing_polygons)),


### PR DESCRIPTION
A downstream script `403_precalculate_fresh_snippets.R` of the database tools crashed in some contexts, namely when run via `Rscript` on the terminal.
The issue is that the function name `extract` is overloaded, and apparently not always associated primarily with `terra`.

The error message was not directly instructive, since it was caused by deviating signature of some other `extract`:

```r
Error in UseMethod("extract") : 
  no applicable method for 'extract' applied to an object of class "SpatRaster"
Calls: source ... same_src.data.frame -> is.data.frame -> as_tibble -> extract
Error in `extract()`:
! Arguments in `...` must be used.
✖ Problematic argument:
• small = FALSE
ℹ Did you misspell an argument name?
```

The issue can simply be solved by making the namespace explicit.


This minor PR just adds two namespace calls; it is not urgent, but I would suggest to also apply similar changes to all other manifestations of the "snippets".
Thank you!