### PR TITLE
aq_piez script: make essential update with regard to type 3130

### DIFF
--- a/010_aq_piezometer_positioning/code_to_be_moved.R
+++ b/010_aq_piezometer_positioning/code_to_be_moved.R
@@ -87,14 +87,32 @@ n2khab_types <-
   arrange(type)
 
 # `wsh` is the watersurface map of Flanders (https://doi.org/10.5281/zenodo.3386857)
-wsh <- read_watersurfaces_hab(interpreted = TRUE)
+wsh <- read_watersurfaces_hab()
 
 # we are interested in the types which are part of the n2khab list
 wsh_occ <-
   wsh$watersurfaces_types %>%
-  # in general we restrict types using an expanded type list tailored to the
-  # type levels present in data sources, but for the aquatic types expansion and
-  # subsequent collapse of types are redundant steps
+  # this code takes a minimum part (for watersurfaces) from collapse_strata() in
+  # the REP at 2dca1a36
+  left_join(
+    tribble(
+      ~main_type, ~subtype,
+      "3130", "3130_aom",
+      "3130", "3130_na"
+    ),
+    join_by(type == main_type),
+    relationship = "many-to-many",
+    unmatched = "drop"
+  ) %>%
+  mutate(
+    type = ifelse(is.na(subtype), type, subtype) %>%
+      as.character() %>%
+      factor(levels = levels(n2khab_types$type))
+  ) %>%
+  select(-subtype) %>%
+  # some polygons can theoretically have had the main type and the subtype, so
+  # we need to deduplicate
+  distinct() %>%
   semi_join(n2khab_types, join_by(type))
 
 # of the focus-type watersurface polygons, we extract the polygon id


### PR DESCRIPTION
This goes hand in hand with a future state of {n2khab} and the REP (probably not the next REP).

@falkmielke I'm making a specific change to this (old) script just because it is still being referred from the code snippets, regarding the geometries of watersurfaces. The PR can be safely merged already, as this particular change does no more than enlarge the spatial sampling frame of watersurfaces, in this standalone 'demo' script. The rest of this script remains outdated though, it's just the particular ways of constructing the geometries and their attributes that still matter.

I plan to incorporate these relevant bits into the code snippets directly when upgrading the watersurface units in the sampling frames. Current PR is just a quick-fix that may already make you update downstream code accordingly.

FYI, there's also a precursor of this code in a side-branch of the REP, that [makes use of](https://github.com/inbo/n2khab-mne-designs/blob/4fb4765d73b24e4707138db520002062e9312025/100_design_common/010_revisitplan/helper_scripts/support_piezposition_aqtypes.R#L28-L35) an updated form of `collapse_strata()` from `R/functions.R` that already contains the left join (that is iterated here in a specific form). This is all just waiting in a separate branch that can only be merged with the `revisitplan` branch when more actions have first been undertaken in the latter, and after {n2khab} got another release.

@falkmielke if you want me to wait with merging, then let me know.